### PR TITLE
fix(rich-text): correct 'Alignement' typo to 'Alignment' in English text (WW-3755)

### DIFF
--- a/ww-config.js
+++ b/ww-config.js
@@ -68,7 +68,7 @@ const textOptions = {
             ],
         },
         label: {
-            en: 'Alignement',
+            en: 'Alignment',
             fr: 'Alignement',
         },
         responsive: true,


### PR DESCRIPTION
## Summary\n- Fixed a typo in the Rich Text widget edition panel, changing 'Alignement' to 'Alignment' in the English text\n\n## Testing\n- Verify the text displays correctly in the English UI